### PR TITLE
Add/remove tags from Posts

### DIFF
--- a/api/postTagData.js
+++ b/api/postTagData.js
@@ -1,0 +1,29 @@
+import clientCredentials from '../utils/data/client';
+
+const endpoint = clientCredentials.databaseURL;
+
+const addPostTag = (payload) => new Promise((resolve, reject) => {
+  fetch(`${endpoint}/postTags`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  })
+    .then((response) => response.json())
+    .then(resolve)
+    .catch(reject);
+});
+
+const removePostTag = (postId, tagId) => new Promise((resolve, reject) => {
+  fetch(`${endpoint}/postTags/${postId}/${tagId}`, {
+    method: 'DELETE',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  })
+    .then(resolve)
+    .catch(reject);
+});
+
+export { addPostTag, removePostTag };

--- a/api/tagData.js
+++ b/api/tagData.js
@@ -1,6 +1,5 @@
 import clientCredentials from '../utils/data/client';
 
-// eslint-disable-next-line no-unused-vars
 const endpoint = clientCredentials.databaseURL;
 
 const getAllTags = () => new Promise((resolve, reject) => {

--- a/components/forms/PostForm.js
+++ b/components/forms/PostForm.js
@@ -1,11 +1,13 @@
 import React, { useEffect, useState } from 'react';
+import CreatableSelect from 'react-select/creatable';
 import PropTypes from 'prop-types';
 import { FloatingLabel, Form } from 'react-bootstrap';
 import { useRouter } from 'next/router';
 import { getUsers } from '../../api/userData';
 import { getCategories } from '../../api/categoryData';
 import { createPost, updatePost } from '../../api/postData';
-// import { getAllTags } from '../../api/tagData';
+import { createTag, getAllTags } from '../../api/tagData';
+import { addPostTag, removePostTag } from '../../api/postTagData';
 
 const nullPost = {
   userId: 0,
@@ -17,19 +19,35 @@ export default function PostForm({ postObj }) {
   const [formData, setFormData] = useState(nullPost);
   const [users, setUsers] = useState([]);
   const [categories, setCategories] = useState([]);
-  // const [tags, setTags] = useState([]);
+  const [tags, setTags] = useState([]);
+  const [selectedTags, setSelectedTags] = useState([]);
+  // const [newTags, setNewTags] = useState([]);
 
   const router = useRouter();
 
   useEffect(() => {
-    if (postObj.id) setFormData(postObj);
+    if (postObj.id) {
+      setFormData({
+        id: postObj.id,
+        userId: postObj.userId,
+        categoryId: postObj.categoryId,
+        title: postObj.title,
+        content: postObj.content,
+        publicationDate: postObj.publicationDate,
+      });
+      setSelectedTags(postObj.tags.map((tag) => ({ value: tag.id, label: tag.label })));
+    }
   }, [postObj]);
 
   useEffect(() => {
     getUsers().then(setUsers);
     getCategories().then(setCategories);
-    // getAllTags().then(setTags);
+    getAllTags().then(setTags);
   }, []);
+
+  const handleTagChange = (selections) => {
+    setSelectedTags(selections);
+  };
 
   const handleChange = (e) => {
     const { name, value } = e.target;
@@ -39,17 +57,37 @@ export default function PostForm({ postObj }) {
     }));
   };
 
+  const managePostTags = async (postId) => {
+    selectedTags.forEach((tag) => {
+      if (typeof tag.value === 'string') {
+        createTag({ label: tag.label }).then(({ id }) => addPostTag({ postId, tagId: id }));
+      } else if (postObj?.tags?.some((postTag) => postTag.id === tag.value)) {
+        console.warn(`Existing ${tag.value}`);
+      } else {
+        addPostTag({ postId, tagId: tag.value });
+      }
+    });
+    postObj?.tags?.forEach((tag) => {
+      if (!selectedTags.some((sTag) => sTag.value === tag.id)) {
+        removePostTag(postId, tag.id);
+      }
+    });
+  };
+
   const handleSubmit = (e) => {
     e.preventDefault();
     if (postObj.id) {
+      managePostTags(postObj.id);
       updatePost(formData).then(() => router.push(`/post/${postObj.id}`));
     } else {
-      createPost({ ...formData, publicationDate: new Date() }).then(({ id }) => router.push(`/post/${id}`));
+      createPost({ ...formData, publicationDate: new Date() }).then(({ id }) => {
+        managePostTags(id).then(() => router.push(`/post/${id}`));
+      });
     }
   };
 
   return (
-    <Form onSubmit={handleSubmit}>
+    <Form onSubmit={handleSubmit} id={234}>
       <FloatingLabel controlId="" label="Post Title" className="mb-3">
         <Form.Control
           type="text"
@@ -118,6 +156,18 @@ export default function PostForm({ postObj }) {
           }
         </Form.Select>
       </FloatingLabel>
+
+      <CreatableSelect
+        instanceId="tagSelect"
+        aria-label="Tags"
+        name="tags"
+        className="mb-3"
+        value={selectedTags}
+        isMulti
+        onChange={handleTagChange}
+        options={tags.map((tag) => ({ value: tag.id, label: tag.label }))}
+      />
+
       <button type="submit">{postObj.id ? 'Update Post' : 'Create Post'}</button>
     </Form>
   );
@@ -130,6 +180,7 @@ PostForm.propTypes = {
     categoryId: PropTypes.number,
     title: PropTypes.string,
     content: PropTypes.string,
+    publicationDate: PropTypes.string,
     tags: PropTypes.arrayOf(PropTypes.shape({
       id: PropTypes.number,
       label: PropTypes.string,

--- a/components/nav/NavBar.js
+++ b/components/nav/NavBar.js
@@ -22,6 +22,9 @@ function AppNavBar() {
             <Link passHref href="/">
               <Nav.Link>Posts</Nav.Link>
             </Link>
+            <Link passHref href="/post/new">
+              <Nav.Link>New Post</Nav.Link>
+            </Link>
             <Link passHref href="/users">
               <Nav.Link>User Manager</Nav.Link>
             </Link>

--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
     "prop-types": "^15.7.2",
     "react": "17.0.2",
     "react-bootstrap": "^2.4.0",
-    "react-dom": "17.0.2"
+    "react-dom": "17.0.2",
+    "react-select": "^5.8.0"
   },
-  
   "devDependencies": {
     "eslint": "^7.32.0",
     "eslint-config-airbnb": "^18.2.1",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,5 +1,6 @@
 /* eslint-disable react/prop-types */
 import 'bootstrap/dist/css/bootstrap.min.css';
+import { SSRProvider } from 'react-bootstrap';
 // import { useRouter } from 'next/router';
 // import { useEffect, useState } from 'react';
 import NavBar from '../components/nav/NavBar';
@@ -8,8 +9,10 @@ import '../styles/globals.css';
 function MyApp({ Component, pageProps }) {
   return (
     <>
-      <NavBar />
-      <Component {...pageProps} />
+      <SSRProvider>
+        <NavBar />
+        <Component {...pageProps} />
+      </SSRProvider>
     </>
   );
 }


### PR DESCRIPTION
## Description
Added multi-select with option creation functionality to PostForm for adding/removing tags from posts
Added addPostTag and removePostTag in new postTagData.js
Added 'New Post' link in nav bar

## Related Issue
#17 #18 

## Motivation and Context
As a user, I want the ability to easily manage which tags are attached to each post.

## How Can This Be Tested?
Server side must use DELETE postTags functional update from branch ab-posttag-delete-edit

Features require react-select. Run:
`npm i --save react-select`
prior to code testing
(If error remains from broken path in import, restart vscode)

From /post/new or /post/edit/[id], add tags either via dropdown or typing new tag and pressing 'Enter'. Tags can also be removed from existing posts.

On submission of form, tags will have been updated on post details page. Check tag manager for any newly created tags.
## Screenshots (if appropriate):
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
[ ] Bug fix (non-breaking change which fixes an issue)
[x] New feature (non-breaking change which adds functionality)
[ ] Breaking change
